### PR TITLE
Send push notifications using Expo

### DIFF
--- a/functions/app.js
+++ b/functions/app.js
@@ -28,6 +28,7 @@ const courses = require('./routes/courses');
 const featured = require('./routes/featured');
 const participants = require('./routes/participants');
 const historic = require('./routes/historic');
+const tokens = require('./routes/tokens');
 
 // Error imports
 const { URL_NOT_FOUND } = require('./errors/codes');
@@ -60,6 +61,7 @@ app.use('/v1/courses',      courses);
 app.use('/v1/featured',     featured);
 app.use('/v1/participants', participants);
 app.use('/v1/historic',     historic);
+app.use('/v1/tokens',       tokens);
 
 // For unhandled routes
 app.all('*', (req, res, next) => {

--- a/functions/app.js
+++ b/functions/app.js
@@ -29,6 +29,7 @@ const featured = require('./routes/featured');
 const participants = require('./routes/participants');
 const historic = require('./routes/historic');
 const tokens = require('./routes/tokens');
+const notifs = require('./routes/notifs');
 
 // Error imports
 const { URL_NOT_FOUND } = require('./errors/codes');
@@ -62,6 +63,7 @@ app.use('/v1/featured',     featured);
 app.use('/v1/participants', participants);
 app.use('/v1/historic',     historic);
 app.use('/v1/tokens',       tokens);
+app.use('/v1/notifs',       notifs);
 
 // For unhandled routes
 app.all('*', (req, res, next) => {

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@babel/code-frame": {
       "version": "7.10.1",
-      "resolved": "https://r.cnpmjs.org/@babel/code-frame/download/@babel/code-frame-7.10.1.tgz",
+      "resolved": "http://r.cnpmjs.org/@babel/code-frame/download/@babel/code-frame-7.10.1.tgz",
       "integrity": "sha1-1UgcUJXaocV+FuVMb5GYRDr7Sf8=",
       "requires": {
         "@babel/highlight": "^7.10.1"
@@ -178,7 +178,7 @@
     },
     "@babel/helper-validator-identifier": {
       "version": "7.10.1",
-      "resolved": "https://r.cnpmjs.org/@babel/helper-validator-identifier/download/@babel/helper-validator-identifier-7.10.1.tgz",
+      "resolved": "http://r.cnpmjs.org/@babel/helper-validator-identifier/download/@babel/helper-validator-identifier-7.10.1.tgz",
       "integrity": "sha1-V3CwwagmxPU/Xt5eFTFj4DGOlLU="
     },
     "@babel/helpers": {
@@ -193,7 +193,7 @@
     },
     "@babel/highlight": {
       "version": "7.10.1",
-      "resolved": "https://r.cnpmjs.org/@babel/highlight/download/@babel/highlight-7.10.1.tgz",
+      "resolved": "http://r.cnpmjs.org/@babel/highlight/download/@babel/highlight-7.10.1.tgz",
       "integrity": "sha1-hB0Ji6YTuhpCeis4PXnjVVLDiuA=",
       "requires": {
         "@babel/helper-validator-identifier": "^7.10.1",
@@ -3938,6 +3938,15 @@
         }
       }
     },
+    "expo-server-sdk": {
+      "version": "3.5.1",
+      "resolved": "https://r.cnpmjs.org/expo-server-sdk/download/expo-server-sdk-3.5.1.tgz",
+      "integrity": "sha1-M6MxekBuS7iILTeZrLburXDVCc4=",
+      "requires": {
+        "node-fetch": "^2.6.0",
+        "promise-limit": "^2.7.0"
+      }
+    },
     "express": {
       "version": "4.17.1",
       "resolved": "http://r.cnpmjs.org/express/download/express-4.17.1.tgz",
@@ -5237,7 +5246,7 @@
     },
     "inquirer": {
       "version": "6.5.2",
-      "resolved": "https://r.cnpmjs.org/inquirer/download/inquirer-6.5.2.tgz",
+      "resolved": "http://r.cnpmjs.org/inquirer/download/inquirer-6.5.2.tgz",
       "integrity": "sha1-rVCUI3XQNtMn/1KMCL1fqwiZKMo=",
       "dev": true,
       "requires": {
@@ -8232,6 +8241,11 @@
       "version": "2.0.3",
       "resolved": "http://r.cnpmjs.org/progress/download/progress-2.0.3.tgz",
       "integrity": "sha1-foz42PW48jnBvGi+tOt4Vn1XLvg="
+    },
+    "promise-limit": {
+      "version": "2.7.0",
+      "resolved": "https://r.cnpmjs.org/promise-limit/download/promise-limit-2.7.0.tgz",
+      "integrity": "sha1-61c3wzNCoDDq6uzqmz06k8tZKyY="
     },
     "promise-polyfill": {
       "version": "8.1.3",

--- a/functions/package.json
+++ b/functions/package.json
@@ -17,6 +17,7 @@
     "@firebase/testing": "^0.20.5",
     "@hapi/joi": "^17.1.1",
     "body-parser": "^1.19.0",
+    "expo-server-sdk": "^3.5.1",
     "firebase-admin": "^8.10.0",
     "firebase-functions": "^3.6.1",
     "firebase-tools": "^8.4.3",

--- a/functions/routes/notifs.js
+++ b/functions/routes/notifs.js
@@ -4,6 +4,7 @@ const Joi = require('@hapi/joi');
 const routes = require('express').Router();
 const admin = require('firebase-admin');
 const db = admin.firestore();
+const { Expo } = require('expo-server-sdk');
 
 const {
   sendNonexistentIdError,
@@ -13,7 +14,9 @@ const {
 const wrap = require('../errors/wrap');
 const { OK } = require('../errors/codes');
 
-const collectionName = 'notifications';
+const notifsCollectionName = 'notifications';
+const ticketsCollectionName = 'tickets';
+const hourToMs = 3.6e6;
 
 const { sendPushNotifs } = require('./util/sendPushNotifs');
 const { firestore } = require('firebase-admin');
@@ -35,9 +38,18 @@ const postSchema = Joi.object({
 /**
  * Notifs endpoints
  * 
- *   POST /notifs
+ *   POST /notifs         - send a message
+ *   POST /notifs/tickets - send all stored tickets to Expo for receipts,
+ *                          log/handle errors, and delete stale receipts
  */
 
+/**
+ * POST /notifs
+ * - Sends a notification to Expo servers with info in the request body
+ *   to all devices registered in our tokens collection
+ * - Stores that notification in a notifications collection
+ * - Stores tickets from Expo in a tickets collection
+ */
 routes.post('/', wrap(async (req, res, next) => {
 
   try {
@@ -52,12 +64,66 @@ routes.post('/', wrap(async (req, res, next) => {
   
   // Store notification data in database for archival reasons
   const dateCreated = new Date();
-  await db.collection(collectionName).add({
+  await db.collection(notifsCollectionName).add({
     ...notification,
     created: firestore.Timestamp.fromDate(dateCreated)
   });
 
   return res.status(OK).send({...notification, created: dateCreated.toString()});
+
+}));
+
+/**
+ * POST /notifs/tickets
+ * - Takes tickets in collection that are at least an hour old and
+ *   sends them to Expo for receipts
+ * - Logs all receipts that contain errors 
+ */
+routes.post('/tickets', wrap(async (req, res, next) => {
+
+  // Grab tickets from collection
+  let receiptIds = [];
+  const tickets = await db.collection(ticketsCollectionName).get();
+  for (let ticketDoc of tickets.docs) {
+    const ticketData = ticketDoc.data();
+
+    // Skip tickets that are younger than an hour
+    const ticketTime = ticketData.created;
+    if (Date.now() - ticketTime.toDate().getTime() < hourToMs) continue;
+
+    // Get all receipt id's from tickets that have them
+    if (ticketData.receiptId) receiptIds.push(ticketData.receiptId);
+  }
+
+  // Chunk receipt ids and handle them as chunks
+  let expo = new Expo();
+  const receiptIdChunks = expo.chunkPushNotificationReceiptIds(receiptIds);
+  for (let chunk of receiptIdChunks) {
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      let receipts = await expo.getPushNotificationReceiptsAsync(chunk);
+      for (let receiptId in receipts) {
+        let { status, message, details } = receipts[receiptId];
+        if (status === 'ok') {
+          console.log('ok');
+          continue;
+        } else if (status === 'error') {
+          console.error(`There was an error sending a notification: ${message}`);
+          if (details && details.error) {
+            console.error(`The error code is ${details.error}`);
+            if (details.error === 'DeviceNotRegistered') {
+              // TODO: set this push token to null
+            }
+            // TODO: handle other errors
+          }
+        }
+      }     
+    } catch (e) {
+      console.error('Error reading receipt id chunks: ', e);
+    }
+  }
+
+  return res.status(OK).send();
 
 }));
 

--- a/functions/routes/notifs.js
+++ b/functions/routes/notifs.js
@@ -123,6 +123,19 @@ routes.post('/tickets', wrap(async (req, res, next) => {
     }
   }
 
+  // Delete tickets that have 'ok' response
+  const successfulTickets = 
+    await db.collection(ticketsCollectionName).where('status', '==', 'ok').get();
+  
+  const successfulTicketIds = [];
+  successfulTickets.forEach(doc => successfulTicketIds.push(doc.id));
+
+  const deletionResults = [];
+  for (let id of successfulTicketIds) {
+    deletionResults.push(db.collection(ticketsCollectionName).doc(id).delete());
+  }
+  await Promise.all(deletionResults);
+
   return res.status(OK).send();
 
 }));

--- a/functions/routes/notifs.js
+++ b/functions/routes/notifs.js
@@ -15,7 +15,7 @@ const { OK } = require('../errors/codes');
 
 const collectionName = 'notifications';
 
-const sendPushNotifs = require('./util/sendPushNotifs');
+const { sendPushNotifs } = require('./util/sendPushNotifs');
 const { firestore } = require('firebase-admin');
 
 /**
@@ -38,7 +38,7 @@ const postSchema = Joi.object({
  *   POST /notifs
  */
 
-routes.post('/', (async (req, res, next) => {
+routes.post('/', wrap(async (req, res, next) => {
 
   try {
     await postSchema.validateAsync(req.body);

--- a/functions/routes/notifs.js
+++ b/functions/routes/notifs.js
@@ -1,0 +1,1 @@
+// Route for sending push notifications to app users

--- a/functions/routes/notifs.js
+++ b/functions/routes/notifs.js
@@ -1,1 +1,50 @@
 // Route for sending push notifications to app users
+
+const Joi = require('@hapi/joi');
+const routes = require('express').Router();
+const admin = require('firebase-admin');
+const db = admin.firestore();
+
+const {
+  sendNonexistentIdError,
+  sendIncorrectTypeError,
+  sendSchemaValidationError,
+} = require('../errors/helpers');
+
+const wrap = require('../errors/wrap');
+const { OK } = require('../errors/codes');
+
+/**
+ * Schematics for notification data data
+ */
+const notifTitle = Joi.string().min(1);
+const notifBody = Joi.string().min(1);
+const notifData = Joi.object();
+
+// Schema for POST requests
+const postSchema = Joi.object({
+  title: notifTitle.required(),
+  body: notifBody.required(),
+  data: notifData
+});
+
+/**
+ * Notifs endpoints
+ * 
+ *   POST /notifs
+ */
+
+routes.post('/', wrap(async (req, res, next) => {
+
+  try {
+    await postSchema.validateAsync(req.body);
+  } catch (e) {
+    return sendSchemaValidationError(res, e);
+  }
+
+  // TODO: send push notification to Expo servers
+  // TODO: store notification data in database for archival reasons ig
+
+}));
+
+module.exports = routes;

--- a/functions/routes/tokens.js
+++ b/functions/routes/tokens.js
@@ -49,10 +49,13 @@ const sendInvalidPushTokenError = (res) => {
 routes.post('/', wrap(async (req, res, next) => {
 
   // Request should include push token as a string
-  const requestPushToken = req.body;
+  const requestPushToken = req.body.pushToken;
 
   if (!Expo.isExpoPushToken(requestPushToken)) {
-    console.error(requestPushToken);
+    console.error(
+      'The following received in POST /v1/tokens and is not a push token: ',
+      requestPushToken
+    );
     return sendInvalidPushTokenError(res);
   }
   
@@ -117,11 +120,14 @@ routes.get('/:id', wrap(async (req, res, next) => {
 routes.put('/:id', wrap(async (req, res, next) => {
 
   // Request should include push token as a string
-  const requestPushToken = req.body;
+  const requestPushToken = req.body.pushToken;
 
   // Check that request body contains valid Expo push token
   if (!Expo.isExpoPushToken(requestPushToken)) {
-    console.error(requestPushToken);
+    console.error(
+      'The following received in PUT /v1/tokens/:id and is not a push token: ', 
+      requestPushToken
+    );
     return sendInvalidPushTokenError(req);
   }
 

--- a/functions/routes/tokens.js
+++ b/functions/routes/tokens.js
@@ -2,41 +2,20 @@
 // Used to hold Expo notification push tokens
 // https://docs.expo.io/push-notifications/sending-notifications/
 
-const Joi = require('@hapi/joi');
 const routes = require('express').Router();
 const admin = require('firebase-admin');
+const { firestore } = require('firebase-admin');
 const { Expo } = require('expo-server-sdk');
 const db = admin.firestore();
-let expo = new Expo();
 
 // Error handling functions/constants
-const {
-  sendNonexistentIdError,
-  sendIncorrectTypeError,
-  sendSchemaValidationError,
-} = require('../errors/helpers');
-
+const {sendNonexistentIdError,} = require('../errors/helpers');
 const wrap = require('../errors/wrap');
 const { OK, INVALID_PARAMS } = require('../errors/codes');
 const { INVALID_REQUEST_ERR } = require('../errors/types');
-const { firestore } = require('firebase-admin');
 
-const collection = 'tokens';
+const collectionName = 'tokens';
 const docName = 'push token';
-
-/**
- * TODO: Schematics for your data
- */
-
-// TODO: schema for POST requests
-const postSchema = Joi.object({
-
-});
-
-// TODO: schema for PUT requests
-const putSchema = Joi.object({
-
-});
 
 const sendInvalidPushTokenError = (res) => {
 
@@ -78,7 +57,7 @@ routes.post('/', wrap(async (req, res, next) => {
   }
   
   // Retrieve existing token if it already exists
-  const tokenCollection = db.collection(collection);
+  const tokenCollection = db.collection(collectionName);
   const receivedCollection = await tokenCollection.get();
   let existingToken = receivedCollection.docs.find(doc => 
     doc.data().pushToken === requestPushToken
@@ -110,7 +89,7 @@ routes.post('/', wrap(async (req, res, next) => {
  */
 routes.get('/:id', wrap(async (req, res, next) => {
 
-  const document = db.collection(collection).doc(req.params.id);
+  const document = db.collection(collectionName).doc(req.params.id);
 
   await document.get().then(doc => {
     if (doc.exists) {
@@ -146,7 +125,7 @@ routes.put('/:id', wrap(async (req, res, next) => {
     return sendInvalidPushTokenError(req);
   }
 
-  const document = db.collection(collection).doc(req.params.id);
+  const document = db.collection(collectionName).doc(req.params.id);
   const docRef = document;
 
   await document.get().then(doc => {
@@ -167,8 +146,9 @@ routes.put('/:id', wrap(async (req, res, next) => {
       lastUpdated: currentDate.toString()
     });
 
-
   });
+
+  return null;
 
 }));
 
@@ -177,7 +157,7 @@ routes.put('/:id', wrap(async (req, res, next) => {
  */
 routes.delete('/:id', wrap(async (req, res, next) => {
 
-  const document = db.collection(collection).doc(req.params.id);
+  const document = db.collection(collectionName).doc(req.params.id);
   const docRef = document;
 
   await document.get().then(doc => {
@@ -196,7 +176,6 @@ routes.delete('/:id', wrap(async (req, res, next) => {
   });
 
 }));
-
 
 
 module.exports = routes;

--- a/functions/routes/tokens.js
+++ b/functions/routes/tokens.js
@@ -1,0 +1,90 @@
+// Tokens API route
+// Used to hold Expo notification push tokens
+// https://docs.expo.io/push-notifications/sending-notifications/
+
+const Joi = require('@hapi/joi');
+const routes = require('express').Router();
+const admin = require('firebase-admin');
+const { Expo } = require('expo-server-sdk');
+const db = admin.firestore();
+
+// Error handling functions/constants
+const {
+  sendNonexistentIdError,
+  sendIncorrectTypeError,
+  sendSchemaValidationError,
+} = require('../errors/helpers');
+
+const wrap = require('../errors/wrap');
+const { OK } = require('../errors/codes');
+
+const collection = 'tokens';
+const docName = 'push token';
+
+/**
+ * TODO: Schematics for your data
+ */
+
+// TODO: schema for POST requests
+const postSchema = Joi.object({
+
+});
+
+// TODO: schema for PUT requests
+const putSchema = Joi.object({
+
+});
+
+/**
+ * Token endpoints
+ * 
+ *   POST             /tokens
+ *   GET, PUT, DELETE /tokens/:id
+ * 
+ * Rationale for endpoints:
+ *   Unlike the other routes, exposing all Expo push tokens could allow
+ *   people to use the endpoint maliciously (ex. sending spam notifications
+ *   using the push tokens). Using Firebase auto-generated ids and providing
+ *   a GET endpoint for only specific tokens will help with development but
+ *   hopefully prevent malicious use of the endpoint.
+ */
+
+/**
+ * POST /tokens
+ */
+routes.post('/', wrap(async (req, res, next) => {
+
+  return res.status(OK).send();
+
+}));
+
+/**
+ * GET /tokens/:id
+ */
+routes.get('/:id', wrap(async (req, res, next) => {
+
+  return res.status(OK).send();
+
+}));
+
+/**
+ * PUT /tokens/:id
+ */
+routes.put('/:id', wrap(async (req, res, next) => {
+
+  return res.status(OK).send();
+
+}));
+
+/**
+ * DELETE /tokens/:id
+ */
+routes.delete('/:id', wrap(async (req, res, next) => {
+
+  return res.status(OK).send();
+
+}));
+
+
+
+module.exports = routes;

--- a/functions/routes/tokens.js
+++ b/functions/routes/tokens.js
@@ -177,7 +177,23 @@ routes.put('/:id', wrap(async (req, res, next) => {
  */
 routes.delete('/:id', wrap(async (req, res, next) => {
 
-  return res.status(OK).send();
+  const document = db.collection(collection).doc(req.params.id);
+  const docRef = document;
+
+  await document.get().then(doc => {
+    if (!doc.exists) {
+      return sendNonexistentIdError(res, req.params.id, docName);
+    }
+    
+    const deletedPushToken = doc.data();
+    docRef.delete();
+
+    // Return string representations of deleted update's Timestamps
+    return res.status(OK).send({
+      pushToken: deletedPushToken.pushToken,
+      lastUpdated: deletedPushToken.lastUpdated.toDate().toString()
+    });
+  });
 
 }));
 

--- a/functions/routes/tokens.js
+++ b/functions/routes/tokens.js
@@ -110,7 +110,25 @@ routes.post('/', wrap(async (req, res, next) => {
  */
 routes.get('/:id', wrap(async (req, res, next) => {
 
-  return res.status(OK).send();
+  const document = db.collection(collection).doc(req.params.id);
+
+  await document.get().then(doc => {
+    if (doc.exists) {
+
+      // Fetch and send data if variation of :id is found
+      let pushTokenDoc = doc.data();
+
+      // Convert Timestamp to string representations of Date
+      return res.status(OK).send({
+        pushToken: pushTokenDoc.pushToken,
+        lastUpdated: pushTokenDoc.lastUpdated.toDate().toString()
+      });
+
+    } else {
+      // If ID is not found, send error response
+      return sendNonexistentIdError(res, req.params.id, docName);
+    }
+  });
 
 }));
 

--- a/functions/routes/updates.js
+++ b/functions/routes/updates.js
@@ -4,6 +4,7 @@ const Joi = require('@hapi/joi');
 const routes = require('express').Router();
 const admin = require('firebase-admin');
 const db = admin.firestore();
+const { sendPushNotifs } = require('./util/sendPushNotifs');
 
 // Error handling functions/constants
 const {
@@ -83,8 +84,12 @@ routes.post('/', wrap(async (req, res, next) => {
   } catch (e) {
     return sendExistingIdError(res, req.body.id, docName);
   }
+
+  // Send push notification about new update
+  const updateBody = req.body.body[0];
+  await sendPushNotifs(req.body.title, updateBody, { screen: 'updates' });
   
-  return res.status(OK).send(req.body);
+  return res.status(OK).send({...req.body, dateCreated: currentDate.toString()});
 
 })); 
 

--- a/functions/routes/util/getTokens.js
+++ b/functions/routes/util/getTokens.js
@@ -6,7 +6,7 @@ const db = admin.firestore();
 /**
  * Grabs all Expo push tokens in Firestore collection
  * @param {String} collectionName name of tokens collection
- * @return {Array} array of Expo push tokens, as strings 
+ * @return {Array<String>} array of Expo push tokens, as strings 
  */
 const getTokens = async (collectionName) => {
   // Query the collection and setup response
@@ -27,3 +27,5 @@ const getTokens = async (collectionName) => {
     return expoPushTokens;
   });
 }
+
+export default getTokens;

--- a/functions/routes/util/getTokens.js
+++ b/functions/routes/util/getTokens.js
@@ -28,4 +28,6 @@ const getTokens = async (collectionName) => {
   });
 }
 
-export default getTokens;
+module.exports = {
+  getTokens
+};

--- a/functions/routes/util/getTokens.js
+++ b/functions/routes/util/getTokens.js
@@ -14,7 +14,7 @@ const getTokens = async (collectionName) => {
   let expoPushTokens = [];
 
   // Get all documents from collection
-  await query.get().then(snapshot => {
+  return await query.get().then(snapshot => {
     let docs = snapshot.docs;
 
     for (let pushTokenDoc of docs) {

--- a/functions/routes/util/getTokens.js
+++ b/functions/routes/util/getTokens.js
@@ -1,1 +1,29 @@
 // Used to get all Expo push tokens in Firestore collection
+
+const admin = require('firebase-admin');
+const db = admin.firestore();
+
+/**
+ * Grabs all Expo push tokens in Firestore collection
+ * @param {String} collectionName name of tokens collection
+ * @return {Array} array of Expo push tokens, as strings 
+ */
+const getTokens = async (collectionName) => {
+  // Query the collection and setup response
+  let query = db.collection(collectionName);
+  let expoPushTokens = [];
+
+  // Get all documents from collection
+  await query.get().then(snapshot => {
+    let docs = snapshot.docs;
+
+    for (let pushTokenDoc of docs) {
+
+      const expoPushToken = pushTokenDoc.data().pushToken;
+      // Put the response doc into the response list
+      expoPushTokens.push(expoPushToken);
+    }
+
+    return expoPushTokens;
+  });
+}

--- a/functions/routes/util/getTokens.js
+++ b/functions/routes/util/getTokens.js
@@ -1,0 +1,1 @@
+// Used to get all Expo push tokens in Firestore collection

--- a/functions/routes/util/sendPushNotifs.js
+++ b/functions/routes/util/sendPushNotifs.js
@@ -48,7 +48,6 @@ const sendPushNotifs = async (title, body, data={}) => {
   let messages = [];
 
   const pushTokens = await getTokens(tokensCollectionName);
-  console.log("sendPushNotifs -> pushTokens", pushTokens)
   for (let pushToken of pushTokens) {
     // Check that each push token is valid
     if (!Expo.isExpoPushToken(pushToken)) {

--- a/functions/routes/util/sendPushNotifs.js
+++ b/functions/routes/util/sendPushNotifs.js
@@ -1,0 +1,1 @@
+// Used to send push notifs and handle errors from Expo regarding notifs

--- a/functions/routes/util/sendPushNotifs.js
+++ b/functions/routes/util/sendPushNotifs.js
@@ -45,7 +45,7 @@ const sendMessageChunks = async (expo, messages) => {
  * @param {String} body body of notification
  * @param {Object} data JSON data to be included in notification
  */
-const sendPushNotifs = async (title, body, data) => {
+const sendPushNotifs = async (title, body, data={}) => {
   let expo = new Expo();
   let messages = [];
 

--- a/functions/routes/util/sendPushNotifs.js
+++ b/functions/routes/util/sendPushNotifs.js
@@ -1,1 +1,68 @@
 // Used to send push notifs and handle errors from Expo regarding notifs
+// https://github.com/expo/expo-server-sdk-node
+
+import getTokens from './getTokens';
+import { Expo } from 'expo-server-sdk';
+
+const tokensCollectionName = 'tokens';
+
+const sendMessageChunks = async (expo, messages) => {
+  // Batch notifications so we don't send too many at once
+  let chunks = expo.chunkPushNotifications(messages);
+  let tickets = [];
+
+  (async () => {
+    // Send each chunk one at a time
+    for (let chunk of chunks) {
+      try {
+        // FIXME: hopefully having await in for loop is ok...
+        // eslint-disable-next-line no-await-in-loop
+        let ticketChunk = await expo.sendPushNotificationsAsync(chunk);
+        console.log(ticketChunk);
+        tickets.push(...ticketChunk);
+      } catch (e) {
+        console.error(e);
+      }
+    }
+  })();
+
+  return tickets;
+}
+
+const sendPushNotifs = async (title, body, data) => {
+  let expo = new Expo();
+  let messages = [];
+
+  const pushTokens = getTokens(tokensCollectionName);
+  for (let pushToken of pushTokens) {
+    // Check that each push token is valid
+    if (!Expo.isExpoPushToken(pushToken)) {
+      console.error(`${pushToken} is not a valid push token`);
+      continue;
+    }
+
+    // Create message body to send
+    // https://docs.expo.io/push-notifications/sending-notifications/#message-request-format
+    messages.push({
+      to: pushToken,
+      sound: 'default',
+      title: title,
+      body: body,
+      badge: 0,
+      data: data
+    });
+  }
+
+  // Send push notifications using Expo
+  try {
+    await sendMessageChunks(expo, messages);
+  } catch (e) {
+    console.error(e);
+  }
+
+  // TODO: handle receipts from tickets
+  // TODO: do we need to store all tickets/receipts in db as well?
+
+}
+
+export default sendPushNotifs;

--- a/functions/routes/util/sendPushNotifs.js
+++ b/functions/routes/util/sendPushNotifs.js
@@ -67,11 +67,22 @@ const sendPushNotifs = async (title, body, data) => {
     });
   }
 
-  // Send push notifications using Expo
+  // Send push notifications using Expo and save tickets
   try {
     const tickets = await sendMessageChunks(expo, messages);
-    // TODO: handle receipts from tickets
-    // TODO: store all tickets in db
+    const formattedTickets = tickets.map((ticket, index) => {
+      // Format each ticket to match schema for Firestore
+      const formattedTicket = {};
+      formattedTicket.status = ticket.status;
+      formattedTicket.expoPushToken = pushTokens[index];  // this may not work
+      if (ticket.id) formattedTicket.receiptId = ticket.id;
+      if (ticket.message) formattedTicket.message = ticket.message;
+      if (ticket.details) formattedTicket.details = ticket.details;
+      return formattedTicket;
+    });
+
+    // TODO: store formatted push tickets in database
+
   } catch (e) {
     console.error(e);
   }

--- a/functions/routes/util/sendPushNotifs.js
+++ b/functions/routes/util/sendPushNotifs.js
@@ -6,6 +6,13 @@ import { Expo } from 'expo-server-sdk';
 
 const tokensCollectionName = 'tokens';
 
+/**
+ * Sends given messages in chunks to Expo servers
+ * 
+ * @param {Expo} expo Expo instance from expo-server-sdk
+ * @param {Array<Object>} messages array of message objects
+ * @returns {Array<ExpoPushTicket>} received push tickets
+ */
 const sendMessageChunks = async (expo, messages) => {
   // Batch notifications so we don't send too many at once
   let chunks = expo.chunkPushNotifications(messages);
@@ -29,6 +36,13 @@ const sendMessageChunks = async (expo, messages) => {
   return tickets;
 }
 
+/**
+ * Sends push notifications to Expo servers
+ * 
+ * @param {String} title title of notification 
+ * @param {String} body body of notification
+ * @param {Object} data JSON data to be included in notification
+ */
 const sendPushNotifs = async (title, body, data) => {
   let expo = new Expo();
   let messages = [];
@@ -55,13 +69,12 @@ const sendPushNotifs = async (title, body, data) => {
 
   // Send push notifications using Expo
   try {
-    await sendMessageChunks(expo, messages);
+    const tickets = await sendMessageChunks(expo, messages);
+    // TODO: handle receipts from tickets
+    // TODO: store all tickets in db
   } catch (e) {
     console.error(e);
   }
-
-  // TODO: handle receipts from tickets
-  // TODO: do we need to store all tickets/receipts in db as well?
 
 }
 

--- a/functions/routes/util/sendPushNotifs.js
+++ b/functions/routes/util/sendPushNotifs.js
@@ -1,10 +1,10 @@
 // Used to send push notifs and handle errors from Expo regarding notifs
 // https://github.com/expo/expo-server-sdk-node
 
-import getTokens from './getTokens';
-import storePushTickets from './storePushTickets';
-import { Expo } from 'expo-server-sdk';
-import { OK } from '../../errors/codes';
+const getTokens = require('./getTokens');
+const storePushTickets = require('./storePushTickets');
+const { Expo } = require('expo-server-sdk');
+const { OK } = require('../../errors/codes');
 
 const tokensCollectionName = 'tokens';
 
@@ -94,4 +94,6 @@ const sendPushNotifs = async (title, body, data={}) => {
 
 }
 
-export default sendPushNotifs;
+module.exports = {
+  sendPushNotifs
+};

--- a/functions/routes/util/sendPushNotifs.js
+++ b/functions/routes/util/sendPushNotifs.js
@@ -2,7 +2,9 @@
 // https://github.com/expo/expo-server-sdk-node
 
 import getTokens from './getTokens';
+import storePushTickets from './storePushTickets';
 import { Expo } from 'expo-server-sdk';
+import { OK } from '../../errors/codes';
 
 const tokensCollectionName = 'tokens';
 
@@ -81,7 +83,10 @@ const sendPushNotifs = async (title, body, data) => {
       return formattedTicket;
     });
 
-    // TODO: store formatted push tickets in database
+    const responseCode = await storePushTickets(formattedTickets);
+    if (responseCode === OK) {
+      console.log('Tickets successfully stored');
+    }
 
   } catch (e) {
     console.error(e);

--- a/functions/routes/util/storePushTickets.js
+++ b/functions/routes/util/storePushTickets.js
@@ -1,5 +1,6 @@
 // Stores Expo push tickets into Firestore
 
+const { OK, SERVER_ERR } = require('../../errors/codes');
 const admin = require('firebase-admin');
 const db = admin.firestore();
 
@@ -20,8 +21,13 @@ const storePushTickets = async (formattedPushTickets) => {
       // Put push ticket into database
       db.collection(collectionName).add(pushTicketDoc);
     }
+
+    return OK;
+
   } catch (e) {
+    // TODO: throw error here to catch by middleware... yeah definitely need to do error classes lol
     console.error('Error storing push tickets', e);
+    return SERVER_ERR;
   }
 }
 

--- a/functions/routes/util/storePushTickets.js
+++ b/functions/routes/util/storePushTickets.js
@@ -5,9 +5,24 @@ const db = admin.firestore();
 
 const collectionName = 'tickets';
 
-
-const storePushTickets = (formattedPushTickets) => {
-
+/**
+ * Adds formatted push tickets to Firestore
+ * @param {Array<Object>} formattedPushTickets push tickets formatted 
+ */
+const storePushTickets = async (formattedPushTickets) => {
+  try {
+    for (let pushTicketDoc of formattedPushTickets) {
+      // If doc doesn't have timestamp already, add it
+      if (pushTicketDoc.created === undefined) {
+        pushTicketDoc.created = admin.firestore.Timestamp.fromDate(new Date());
+      }
+  
+      // Put push ticket into database
+      db.collection(collectionName).add(pushTicketDoc);
+    }
+  } catch (e) {
+    console.error('Error storing push tickets', e);
+  }
 }
 
 export default storePushTickets;

--- a/functions/routes/util/storePushTickets.js
+++ b/functions/routes/util/storePushTickets.js
@@ -1,0 +1,13 @@
+// Stores Expo push tickets into Firestore
+
+const admin = require('firebase-admin');
+const db = admin.firestore();
+
+const collectionName = 'tickets';
+
+
+const storePushTickets = (formattedPushTickets) => {
+
+}
+
+export default storePushTickets;

--- a/functions/routes/util/storePushTickets.js
+++ b/functions/routes/util/storePushTickets.js
@@ -11,6 +11,8 @@ const collectionName = 'tickets';
  * @param {Array<Object>} formattedPushTickets push tickets formatted 
  */
 const storePushTickets = async (formattedPushTickets) => {
+  const results = [];
+
   try {
     for (let pushTicketDoc of formattedPushTickets) {
       // If doc doesn't have timestamp already, add it
@@ -19,10 +21,11 @@ const storePushTickets = async (formattedPushTickets) => {
       }
   
       // Put push ticket into database
-      db.collection(collectionName).add(pushTicketDoc);
+      results.push(db.collection(collectionName).add(pushTicketDoc));
     }
 
-    return OK;
+    const awaitResults = await Promise.all(results);
+    return awaitResults;
 
   } catch (e) {
     // TODO: throw error here to catch by middleware... yeah definitely need to do error classes lol

--- a/functions/routes/util/storePushTickets.js
+++ b/functions/routes/util/storePushTickets.js
@@ -31,4 +31,6 @@ const storePushTickets = async (formattedPushTickets) => {
   }
 }
 
-export default storePushTickets;
+module.exports = {
+  storePushTickets
+};

--- a/hhx-api.wiki/Tokens.md
+++ b/hhx-api.wiki/Tokens.md
@@ -23,7 +23,7 @@ The documentation for this endpoint will also be limited.
 ```
 The `lastUpdated` field will be kept in Firebase internally as a Timestamp, but will be converted to a string upon retrieval.
 
-When performing `POST` and `PUT` requests, make sure the header `Content-Type` is set to `text/plain`, and include just the Expo push token as a string in the request body.
+When performing `POST` and `PUT` requests, send the push token in the field as designated in the schema - all other fields will be ignored.
 
 `POST` and `PUT` endpoints will evaluate each push token using methods provided by `expo-server-sdk`. If any requests contain invalid push tokens, they will return errors (of which the format will look like something from [here](errors)).
 

--- a/hhx-api.wiki/Tokens.md
+++ b/hhx-api.wiki/Tokens.md
@@ -1,0 +1,40 @@
+# Tokens endpoint
+The Hip Hop Xpress mobile app uses Expo to send push notifications to its users. This endpoint keeps track of *push tokens* used by Expo to send those notifications. 
+
+Generally, this endpoint route should only be used by developers of the HHX mobile app, so the available endpoints are limited to those below:
+
+```javascript
+   POST /v1/tokens
+
+    GET /v1/tokens/:id
+    PUT /v1/tokens/:id
+ DELETE /v1/tokens/:id
+```
+
+The documentation for this endpoint will also be limited.
+
+## Schema
+`POST` and `PUT` endpoints will evaluate each push token using methods provided by `expo-server-sdk`. If any requests contain invalid push tokens, they will return errors (of which the format is TBD).
+
+# Endpoints:
+
+## Register device's push token to collection
+`POST /v1/tokens`
+
+Upon startup of the app, the device will send its push token to this endpoint. If the push token is not already in the collection, it will be added - otherwise, no change occurs.
+
+
+## Retrieve a device's push token
+`GET /v1/tokens/:id`
+
+If given an `id` of a push token in the collection, the endpoint will return the requested push token.
+
+## Update a device's push token
+`PUT /v1/tokens/:id`
+
+Given an `id` and a valid push token in the request body, the endpoint will update the push token at that `id` and return the request body as is.
+
+## Delete a device's push token
+`DELETE /v1/tokens/:id`
+
+Given an `id`, the endpoint will delete the push token at that `id`.

--- a/hhx-api.wiki/Tokens.md
+++ b/hhx-api.wiki/Tokens.md
@@ -49,3 +49,22 @@ Given an `id` and a valid push token in the request body, the endpoint will upda
 `DELETE /v1/tokens/:id`
 
 Given an `id`, the endpoint will delete the push token at that `id`.
+
+# Tickets
+Whenever a push notification is sent, it sends back a ticket. These need to be stored to be assessed in case errors occur when sending push notifications.
+
+They will be stored in the following format:
+```json
+{
+  "status": "status of request",
+  "message": "message or null",
+  "details": {
+    "error": "some error code, 'details' can also be null"
+  },
+  "expoPushToken": "the push token if successful",
+  "receiptId": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX",
+  "created": "kept as Timestamp in Firestore"
+}
+```
+
+#### [Back to top](#tokens-endpoint)

--- a/hhx-api.wiki/Tokens.md
+++ b/hhx-api.wiki/Tokens.md
@@ -14,6 +14,7 @@ Generally, this endpoint route should only be used by developers of the HHX mobi
 The documentation for this endpoint will also be limited.
 
 ## Schema
+**NOTE: *this is very likely to change!***
 ```json
 {
   "pushToken": "ExponentPushToken[**********************]",
@@ -22,7 +23,9 @@ The documentation for this endpoint will also be limited.
 ```
 The `lastUpdated` field will be kept in Firebase internally as a Timestamp, but will be converted to a string upon retrieval.
 
-`POST` and `PUT` endpoints will evaluate each push token using methods provided by `expo-server-sdk`. If any requests contain invalid push tokens, they will return errors (of which the format is TBD).
+When performing `POST` and `PUT` requests, make sure the header `Content-Type` is set to `text/plain`, and include just the Expo push token as a string in the request body.
+
+`POST` and `PUT` endpoints will evaluate each push token using methods provided by `expo-server-sdk`. If any requests contain invalid push tokens, they will return errors (of which the format will look like something from [here](errors)).
 
 # Endpoints:
 

--- a/hhx-api.wiki/Tokens.md
+++ b/hhx-api.wiki/Tokens.md
@@ -14,6 +14,14 @@ Generally, this endpoint route should only be used by developers of the HHX mobi
 The documentation for this endpoint will also be limited.
 
 ## Schema
+```json
+{
+  "pushToken": "ExponentPushToken[**********************]",
+  "lastUpdated": "some timestamp information as a string"
+}
+```
+The `lastUpdated` field will be kept in Firebase internally as a Timestamp, but will be converted to a string upon retrieval.
+
 `POST` and `PUT` endpoints will evaluate each push token using methods provided by `expo-server-sdk`. If any requests contain invalid push tokens, they will return errors (of which the format is TBD).
 
 # Endpoints:


### PR DESCRIPTION
Tasks:

- Keep collection of all Expo push notifications by enabling POST requests to a `tokens` collection
- Create function that sends push notifications to all push tokens upon certain requests
  - Could be an entirely new endpoint route that allows users with authorization to send push notifications on the fly
  - Will definitely link to creating Updates


closes #43 